### PR TITLE
Keen Slider fix for deletion of the last slider

### DIFF
--- a/src/components/home/HotCollections.jsx
+++ b/src/components/home/HotCollections.jsx
@@ -95,7 +95,7 @@ const HotCollections = () => {
                       </div>
                     </div>
                   ))
-                : new Array(4).fill(0).map((_, index) => (
+                : new Array(6).fill(0).map((_, index) => (
                     <div
                       className="col-lg-3 col-md-6 col-sm-6 col-xs-12 keen-slider__slide"
                       key={index}
@@ -103,7 +103,7 @@ const HotCollections = () => {
                       <div className="nft_coll">
                         <div className="nft_wrap">
                           <Link to="/">
-                            <Skeleton width={"100%"} height={"80%"} />
+                            <Skeleton width={"100%"} height={"auto"} />
                           </Link>
                         </div>
                         <div className="nft_coll_pp">


### PR DESCRIPTION
Task:
Repair the Keen Slider from deleting the last slider in the carousel

How:
My logic is that because of the skeleton having only 4 sliders and the keen slider panels being set for 4 per view, it would create a problem when it wouldn't know where to pull the 5th slider from when the data loaded. Solution was to add 6 sliders instead of 4 for the skeleton loading phase.
